### PR TITLE
F_pr family modified

### DIFF
--- a/R/compute_terms.R
+++ b/R/compute_terms.R
@@ -61,7 +61,7 @@ compute_terms.xde <- function(varslist, deout, pars, s, i) {
   ni = list()
   for(i in 1:pars$nHosts){
     ni[[i]] = compute_NI(deout, pars, i)
-    pr[[i]] = F_pr(varslist, pars, i)
+    pr[[i]] = F_pr(varslist$XH[[i]], pars$Xpar[[i]])
   }
 
   return(list(time=time,eir=eir,pr=pr,ni=ni,kappa=kappa,fqZ=fqZ))
@@ -83,7 +83,7 @@ compute_terms.cohort <- function(varslist, deout, pars, s, i) {
   ni = list()
   for(i in 1:pars$nHosts){
     ni[[i]] = compute_NI(deout, pars, i)
-    pr[[i]] = F_pr(varslist, pars, i)
+    pr[[i]] = F_pr(varslist$XH[[i]], pars$Xpar[[i]])
   }
 
   return(list(time=time,eir=eir,pr=pr,ni=ni))
@@ -124,7 +124,7 @@ compute_terms.human<- function(varslist, deout, pars, s, i) {
   ni = list()
   for(i in 1:pars$nHosts){
     ni[[i]] = compute_NI(deout, pars, i)
-    pr[[i]] = F_pr(varslist, pars, i)
+    pr[[i]] = F_pr(varslist$XH[[i]], pars$Xpar[[i]])
   }
 
   return(list(time=time,eir=eir,pr=pr,ni=ni,fqZ=fqZ))
@@ -156,7 +156,7 @@ compute_terms_steady<- function(varslist, y_eq, pars, s, i) {
   eir = pars$EIR[[1]]
   fqZ <- F_fqZ(0, y_eq, pars, s)
   ni <- F_X(0, y_eq, pars, i)/varslist$XH[[i]]$H
-  pr <- F_pr(varslist, pars, i)
+  pr <- F_pr(varslist$XH[[i]], pars$Xpar[[i]])
   return(list(eir=eir,pr=pr,kappa=kappa,fqZ=fqZ,ni=ni))
 }
 

--- a/R/human-SEIS.R
+++ b/R/human-SEIS.R
@@ -278,8 +278,8 @@ HTC.SEIS <- function(pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr.SEIS <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr.SEIS <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -288,8 +288,8 @@ F_pr.SEIS <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_lm.SEIS <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_lm.SEIS <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -298,8 +298,8 @@ F_pr_by_lm.SEIS <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_rdt.SEIS <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_rdt.SEIS <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -308,8 +308,8 @@ F_pr_by_rdt.SEIS <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_pcr.SEIS <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_pcr.SEIS <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 

--- a/R/human-SEISd.R
+++ b/R/human-SEISd.R
@@ -292,8 +292,8 @@ HTC.SEISd <- function(pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr.SEISd <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr.SEISd <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -302,8 +302,8 @@ F_pr.SEISd <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_lm.SEISd <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_lm.SEISd <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -312,8 +312,8 @@ F_pr_by_lm.SEISd <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_rdt.SEISd <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_rdt.SEISd <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -322,8 +322,8 @@ F_pr_by_rdt.SEISd <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_pcr.SEISd <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_pcr.SEISd <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 

--- a/R/human-SIP.R
+++ b/R/human-SIP.R
@@ -318,8 +318,8 @@ get_inits_X.SIP <- function(pars, i){with(pars$Xinits[[i]],{
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr.SIP <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr.SIP <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -328,8 +328,8 @@ F_pr.SIP <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_lm.SIP <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_lm.SIP <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -338,8 +338,8 @@ F_pr_by_lm.SIP <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_rdt.SIP <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_rdt.SIP <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -348,8 +348,8 @@ F_pr_by_rdt.SIP <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_pcr.SIP <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_pcr.SIP <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 

--- a/R/human-SIS.R
+++ b/R/human-SIS.R
@@ -180,7 +180,8 @@ list_Xvars.SIS <- function(y, pars, i) {
   with(pars$ix$X[[i]],
        return(list(
          S = y[S_ix],
-         I = y[I_ix]
+         I = y[I_ix],
+         H <- F_H(t, y, pars, i)
        )
        ))
 }
@@ -254,8 +255,8 @@ parse_outputs_X.SIS <- function(outputs, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr.SIS <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr.SIS <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -264,8 +265,8 @@ F_pr.SIS <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_lm.SIS <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_lm.SIS <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -274,8 +275,8 @@ F_pr_by_lm.SIS <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_rdt.SIS <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_rdt.SIS <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 
@@ -284,8 +285,8 @@ F_pr_by_rdt.SIS <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_pcr.SIS <- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], I/H)
+F_pr_by_pcr.SIS <- function(vars, Xpar) {
+  pr = with(vars, I/H)
   return(pr)
 }
 

--- a/R/human-hMoI.R
+++ b/R/human-hMoI.R
@@ -233,8 +233,8 @@ get_inits_X.hMoI <- function(pars, i){with(pars$Xinits[[i]],{
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr.hMoI<- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], 1-exp(-m1))
+F_pr.hMoI<- function(vars, Xpar) {
+  pr = with(vars, 1-exp(-m1))
   return(pr)
 }
 
@@ -243,8 +243,8 @@ F_pr.hMoI<- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_lm.hMoI<- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], 1-exp(-m1))
+F_pr_by_lm.hMoI<- function(vars, Xpar) {
+  pr = with(vars, 1-exp(-m1))
   return(pr)
 }
 
@@ -253,8 +253,8 @@ F_pr_by_lm.hMoI<- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_rdt.hMoI<- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], 1-exp(-m1))
+F_pr_by_rdt.hMoI<- function(vars, Xpar) {
+  pr = with(vars, 1-exp(-m1))
   return(pr)
 }
 
@@ -263,7 +263,7 @@ F_pr_by_rdt.hMoI<- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_pcr.hMoI<- function(varslist, pars, i) {
-  pr = with(varslist$XH[[i]], 1-exp(-m1))
+F_pr_by_pcr.hMoI<- function(vars, Xpar) {
+  pr = with(vars, 1-exp(-m1))
   return(pr)
 }

--- a/R/human-interface.R
+++ b/R/human-interface.R
@@ -164,16 +164,14 @@ update_inits_X <- function(pars, y0, i) {
   UseMethod("update_inits_X", pars$Xpar[[i]])
 }
 
-
 #' @title Compute the "true" prevalence of infection / parasite rate
 #' @description This method dispatches on the type of `pars$Xpar[[i]]`.
-#' @param varslist a parsed list of outputs with variables attached by name
-#' @param pars a list
-#' @param i the host species index
+#' @param vars a list with the variables attached by name
+#' @param Xpar a list defining a model for human
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr <- function(varslist, pars, i) {
-  UseMethod("F_pr", pars$Xpar[[i]])
+F_pr <- function(vars, Xpar) {
+  UseMethod("F_pr", Xpar)
 }
 
 #' @title Compute the prevalence of infection by light microscopy
@@ -181,8 +179,8 @@ F_pr <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_lm <- function(varslist, pars, i) {
-  UseMethod("F_pr", pars$Xpar[[i]])
+F_pr_by_lm <- function(vars, Xpar) {
+  UseMethod("F_pr", Xpar)
 }
 
 #' @title Compute the prevalence of infection by RDT
@@ -190,8 +188,8 @@ F_pr_by_lm <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_rdt <- function(varslist, pars, i) {
-  UseMethod("F_pr", pars$Xpar[[i]])
+F_pr_by_rdt <- function(vars, Xpar) {
+  UseMethod("F_pr", Xpar)
 }
 
 #' @title Compute the prevalence of infection by PCR
@@ -199,8 +197,8 @@ F_pr_by_rdt <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector of length `nStrata`
 #' @export
-F_pr_by_pcr <- function(varslist, pars, i) {
-  UseMethod("F_pr", pars$Xpar[[i]])
+F_pr_by_pcr <- function(vars, Xpar) {
+  UseMethod("F_pr", Xpar)
 }
 
 

--- a/R/human-trace.R
+++ b/R/human-trace.R
@@ -23,7 +23,7 @@ F_H.trace <- function(t, y, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector numeric(0)
 #' @export
-F_pr.trace <- function(varslist, pars, i) {
+F_pr.trace <- function(vars, Xpar) {
   return(numeric(0))
 }
 
@@ -32,7 +32,7 @@ F_pr.trace <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector numeric(0)
 #' @export
-F_pr_by_lm.trace <- function(varslist, pars, i) {
+F_pr_by_lm.trace <- function(vars, Xpar) {
   return(numeric(0))
 }
 
@@ -42,7 +42,7 @@ F_pr_by_lm.trace <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector numeric(0)
 #' @export
-F_pr_by_rdt.trace <- function(varslist, pars, i) {
+F_pr_by_rdt.trace <- function(vars, Xpar) {
   return(numeric(0))
 }
 
@@ -52,7 +52,7 @@ F_pr_by_rdt.trace <- function(varslist, pars, i) {
 #' @inheritParams F_pr
 #' @return a [numeric] vector numeric(0)
 #' @export
-F_pr_by_pcr.trace <- function(varslist, pars, i) {
+F_pr_by_pcr.trace <- function(vars, Xpar) {
   return(numeric(0))
 }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## What is ramp.xds?
 
-**ramp.xds** is an R software package to set up, analyze, and solve dynamical systems describing the epidemiology, dynamics and control of malaria and other mosquito-borne pathogens. The software was designed around a rigorous mathematical framework, described in [Spatial Dynamics of Malaria Transmission](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1010684) published in PLoS Computational Biology^[Wu SL, Henry JM, Citron DT, Mbabazi Ssebuliba D, Nakakawa Nsumba J, Sánchez C. HM, et al. (2023) Spatial dynamics of malaria transmission. PLoS Comput Biol 19(6): e1010684. https://doi.org/10.1371/journal.pcbi.1010684]. 
+**ramp.xds** is an R software package to set up, analyze, and solve dynamical systems describing the epidemiology, transmission dynamics, and control of malaria and other mosquito-borne pathogens. The software was designed around a rigorous mathematical framework, described in [Spatial Dynamics of Malaria Transmission](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1010684) published in PLoS Computational Biology^[Wu SL, Henry JM, Citron DT, Mbabazi Ssebuliba D, Nakakawa Nsumba J, Sánchez C. HM, et al. (2023) Spatial dynamics of malaria transmission. PLoS Comput Biol 19(6): e1010684. https://doi.org/10.1371/journal.pcbi.1010684]. This software is part of a set designed to support robust analytics for malaria policy (RAMP) and adaptive malaria control:
 
 + *ramp.xds* handles core computation. It is being actively developed, and it is a continuation of two deprecated software packages: [*exDE*](https://dd-harp.github.io/exDE/) and [*MicroMoB*](https://dd-harp.github.io/MicroMoB/).
 
@@ -20,8 +20,6 @@
 + A library of stable, verifiable, reusable code implementing a large set of previously published models for *ramp.xds* is maintained in [**ramp.library**](https://dd-harp.github.io/ramp.library/). 
 
 + Algorithms to apply these models, include code to fit models to data, is found in [**ramp.work**](https://dd-harp.github.io/ramp.work/). 
-
-This software is part of a suite of R packages that support robust analytics for malaria policy (RAMP) and adaptive malaria control. 
 
 
 ## Installation

--- a/docs/index.html
+++ b/docs/index.html
@@ -177,14 +177,13 @@
 <div class="section level2">
 <h2 id="what-is-rampxds">What is ramp.xds?<a class="anchor" aria-label="anchor" href="#what-is-rampxds"></a>
 </h2>
-<p><strong>ramp.xds</strong> is an R software package to set up, analyze, and solve dynamical systems describing the epidemiology, dynamics and control of malaria and other mosquito-borne pathogens. The software was designed around a rigorous mathematical framework, described in <a href="https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1010684" class="external-link">Spatial Dynamics of Malaria Transmission</a> published in PLoS Computational Biology<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a>.</p>
+<p><strong>ramp.xds</strong> is an R software package to set up, analyze, and solve dynamical systems describing the epidemiology, transmission dynamics, and control of malaria and other mosquito-borne pathogens. The software was designed around a rigorous mathematical framework, described in <a href="https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1010684" class="external-link">Spatial Dynamics of Malaria Transmission</a> published in PLoS Computational Biology<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a>. This software is part of a set designed to support robust analytics for malaria policy (RAMP) and adaptive malaria control:</p>
 <ul>
 <li><p><em>ramp.xds</em> handles core computation. It is being actively developed, and it is a continuation of two deprecated software packages: <a href="https://dd-harp.github.io/exDE/" class="external-link"><em>exDE</em></a> and <a href="https://dd-harp.github.io/MicroMoB/" class="external-link"><em>MicroMoB</em></a>.</p></li>
 <li><p>Several examples illustrating capabilities are found in <a href="https://dd-harp.github.io/ramp.malaria/" class="external-link"><strong>ramp.malaria</strong></a>.</p></li>
 <li><p>A library of stable, verifiable, reusable code implementing a large set of previously published models for <em>ramp.xds</em> is maintained in <a href="https://dd-harp.github.io/ramp.library/" class="external-link"><strong>ramp.library</strong></a>.</p></li>
 <li><p>Algorithms to apply these models, include code to fit models to data, is found in <a href="https://dd-harp.github.io/ramp.work/" class="external-link"><strong>ramp.work</strong></a>.</p></li>
 </ul>
-<p>This software is part of a suite of R packages that support robust analytics for malaria policy (RAMP) and adaptive malaria control.</p>
 </div>
 <div class="section level2">
 <h2 id="installation">Installation<a class="anchor" aria-label="anchor" href="#installation"></a>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -20,7 +20,7 @@ articles:
   spat_metric: spat_metric.html
   Understanding_ramp.xds: Understanding_ramp.xds.html
   vc_lemenach: vc_lemenach.html
-last_built: 2024-07-05T20:20Z
+last_built: 2024-07-06T15:09Z
 urls:
   reference: https://dd-harp.github.io/ramp.xde/reference
   article: https://dd-harp.github.io/ramp.xde/articles

--- a/docs/reference/Births.zero.html
+++ b/docs/reference/Births.zero.html
@@ -130,7 +130,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Derivatives of demographic changes in human populations</h1>
-    <small class="dont-index">Source: <a href="https://github.com/dd-harp/ramp.xde/blob/HEAD/R/human-births.R" class="external-link"><code>R/human-births.R</code></a></small>
+    <small class="dont-index">Source: <a href="https://github.com/dd-harp/ramp.xde/blob/HEAD/R/human-demography-births.R" class="external-link"><code>R/human-demography-births.R</code></a></small>
     <div class="hidden name"><code>Births.zero.Rd</code></div>
     </div>
 

--- a/docs/reference/F_pr.SEIS.html
+++ b/docs/reference/F_pr.SEIS.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SEIS</span></span>
-<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr.SEISd.html
+++ b/docs/reference/F_pr.SEISd.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SEISd</span></span>
-<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr.SIP.html
+++ b/docs/reference/F_pr.SIP.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SIP</span></span>
-<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr.SIS.html
+++ b/docs/reference/F_pr.SIS.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SIS</span></span>
-<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr.hMoI.html
+++ b/docs/reference/F_pr.hMoI.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for hMoI</span></span>
-<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr.html
+++ b/docs/reference/F_pr.html
@@ -139,21 +139,17 @@
     </div>
 
     <div id="ref-usage">
-    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">F_pr</span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">F_pr</span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr.trace.html
+++ b/docs/reference/F_pr.trace.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for trace</span></span>
-<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr.html">F_pr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_lm.SEIS.html
+++ b/docs/reference/F_pr_by_lm.SEIS.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SEIS</span></span>
-<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_lm.SEISd.html
+++ b/docs/reference/F_pr_by_lm.SEISd.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SEISd</span></span>
-<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_lm.SIP.html
+++ b/docs/reference/F_pr_by_lm.SIP.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SIP</span></span>
-<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_lm.SIS.html
+++ b/docs/reference/F_pr_by_lm.SIS.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SIS</span></span>
-<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_lm.hMoI.html
+++ b/docs/reference/F_pr_by_lm.hMoI.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for hMoI</span></span>
-<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_lm.html
+++ b/docs/reference/F_pr_by_lm.html
@@ -139,21 +139,17 @@
     </div>
 
     <div id="ref-usage">
-    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">F_pr_by_lm</span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">F_pr_by_lm</span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_lm.trace.html
+++ b/docs/reference/F_pr_by_lm.trace.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for trace</span></span>
-<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_lm.html">F_pr_by_lm</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_pcr.SEIS.html
+++ b/docs/reference/F_pr_by_pcr.SEIS.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SEIS</span></span>
-<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_pcr.SEISd.html
+++ b/docs/reference/F_pr_by_pcr.SEISd.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SEISd</span></span>
-<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_pcr.SIP.html
+++ b/docs/reference/F_pr_by_pcr.SIP.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SIP</span></span>
-<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_pcr.SIS.html
+++ b/docs/reference/F_pr_by_pcr.SIS.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SIS</span></span>
-<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_pcr.hMoI.html
+++ b/docs/reference/F_pr_by_pcr.hMoI.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for hMoI</span></span>
-<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_pcr.html
+++ b/docs/reference/F_pr_by_pcr.html
@@ -139,21 +139,17 @@
     </div>
 
     <div id="ref-usage">
-    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">F_pr_by_pcr</span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">F_pr_by_pcr</span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_pcr.trace.html
+++ b/docs/reference/F_pr_by_pcr.trace.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for trace</span></span>
-<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_pcr.html">F_pr_by_pcr</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_rdt.SEIS.html
+++ b/docs/reference/F_pr_by_rdt.SEIS.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SEIS</span></span>
-<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_rdt.SEISd.html
+++ b/docs/reference/F_pr_by_rdt.SEISd.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SEISd</span></span>
-<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_rdt.SIP.html
+++ b/docs/reference/F_pr_by_rdt.SIP.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SIP</span></span>
-<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_rdt.SIS.html
+++ b/docs/reference/F_pr_by_rdt.SIS.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for SIS</span></span>
-<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_rdt.hMoI.html
+++ b/docs/reference/F_pr_by_rdt.hMoI.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for hMoI</span></span>
-<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_rdt.html
+++ b/docs/reference/F_pr_by_rdt.html
@@ -139,21 +139,17 @@
     </div>
 
     <div id="ref-usage">
-    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">F_pr_by_rdt</span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">F_pr_by_rdt</span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/F_pr_by_rdt.trace.html
+++ b/docs/reference/F_pr_by_rdt.trace.html
@@ -140,21 +140,17 @@
 
     <div id="ref-usage">
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="co"># S3 method for trace</span></span>
-<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">varslist</span>, <span class="va">pars</span>, <span class="va">i</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="F_pr_by_rdt.html">F_pr_by_rdt</a></span><span class="op">(</span><span class="va">vars</span>, <span class="va">Xpar</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
-    <dl><dt>varslist</dt>
-<dd><p>a parsed list of outputs with variables attached by name</p></dd>
+    <dl><dt>vars</dt>
+<dd><p>a list with the variables attached by name</p></dd>
 
 
-<dt>pars</dt>
-<dd><p>a list</p></dd>
-
-
-<dt>i</dt>
-<dd><p>the host species index</p></dd>
+<dt>Xpar</dt>
+<dd><p>a list defining a model for human infections</p></dd>
 
 </dl></div>
     <div id="value">

--- a/docs/reference/dHdt.zero.html
+++ b/docs/reference/dHdt.zero.html
@@ -130,7 +130,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Derivatives of demographic changes in human populations</h1>
-    <small class="dont-index">Source: <a href="https://github.com/dd-harp/ramp.xde/blob/HEAD/R/human-dHdt.R" class="external-link"><code>R/human-dHdt.R</code></a></small>
+    <small class="dont-index">Source: <a href="https://github.com/dd-harp/ramp.xde/blob/HEAD/R/human-demography-dHdt.R" class="external-link"><code>R/human-demography-dHdt.R</code></a></small>
     <div class="hidden name"><code>dHdt.zero.Rd</code></div>
     </div>
 

--- a/man/F_pr.Rd
+++ b/man/F_pr.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr}
 \title{Compute the "true" prevalence of infection / parasite rate}
 \usage{
-F_pr(varslist, pars, i)
+F_pr(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr.SEIS.Rd
+++ b/man/F_pr.SEIS.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr.SEIS}
 \title{Compute the "true" prevalence of infection / parasite rate}
 \usage{
-\method{F_pr}{SEIS}(varslist, pars, i)
+\method{F_pr}{SEIS}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr.SEISd.Rd
+++ b/man/F_pr.SEISd.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr.SEISd}
 \title{Compute the "true" prevalence of infection / parasite rate}
 \usage{
-\method{F_pr}{SEISd}(varslist, pars, i)
+\method{F_pr}{SEISd}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr.SIP.Rd
+++ b/man/F_pr.SIP.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr.SIP}
 \title{Compute the "true" prevalence of infection / parasite rate}
 \usage{
-\method{F_pr}{SIP}(varslist, pars, i)
+\method{F_pr}{SIP}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr.SIS.Rd
+++ b/man/F_pr.SIS.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr.SIS}
 \title{Compute the "true" prevalence of infection / parasite rate}
 \usage{
-\method{F_pr}{SIS}(varslist, pars, i)
+\method{F_pr}{SIS}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr.hMoI.Rd
+++ b/man/F_pr.hMoI.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr.hMoI}
 \title{Compute the "true" prevalence of infection / parasite rate}
 \usage{
-\method{F_pr}{hMoI}(varslist, pars, i)
+\method{F_pr}{hMoI}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr.trace.Rd
+++ b/man/F_pr.trace.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr.trace}
 \title{Compute the "true" prevalence of infection / parasite rate}
 \usage{
-\method{F_pr}{trace}(varslist, pars, i)
+\method{F_pr}{trace}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector numeric(0)

--- a/man/F_pr_by_lm.Rd
+++ b/man/F_pr_by_lm.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_lm}
 \title{Compute the prevalence of infection by light microscopy}
 \usage{
-F_pr_by_lm(varslist, pars, i)
+F_pr_by_lm(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_lm.SEIS.Rd
+++ b/man/F_pr_by_lm.SEIS.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_lm.SEIS}
 \title{Compute the prevalence of infection by light microscopy}
 \usage{
-\method{F_pr_by_lm}{SEIS}(varslist, pars, i)
+\method{F_pr_by_lm}{SEIS}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_lm.SEISd.Rd
+++ b/man/F_pr_by_lm.SEISd.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_lm.SEISd}
 \title{Compute the prevalence of infection by light microscopy}
 \usage{
-\method{F_pr_by_lm}{SEISd}(varslist, pars, i)
+\method{F_pr_by_lm}{SEISd}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_lm.SIP.Rd
+++ b/man/F_pr_by_lm.SIP.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_lm.SIP}
 \title{Compute the prevalence of infection by light microscopy}
 \usage{
-\method{F_pr_by_lm}{SIP}(varslist, pars, i)
+\method{F_pr_by_lm}{SIP}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_lm.SIS.Rd
+++ b/man/F_pr_by_lm.SIS.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_lm.SIS}
 \title{Compute the prevalence of infection by light microscopy}
 \usage{
-\method{F_pr_by_lm}{SIS}(varslist, pars, i)
+\method{F_pr_by_lm}{SIS}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_lm.hMoI.Rd
+++ b/man/F_pr_by_lm.hMoI.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_lm.hMoI}
 \title{Compute the prevalence of infection by light microscopy}
 \usage{
-\method{F_pr_by_lm}{hMoI}(varslist, pars, i)
+\method{F_pr_by_lm}{hMoI}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_lm.trace.Rd
+++ b/man/F_pr_by_lm.trace.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_lm.trace}
 \title{Compute the prevalence of infection by light microscopy}
 \usage{
-\method{F_pr_by_lm}{trace}(varslist, pars, i)
+\method{F_pr_by_lm}{trace}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector numeric(0)

--- a/man/F_pr_by_pcr.Rd
+++ b/man/F_pr_by_pcr.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_pcr}
 \title{Compute the prevalence of infection by PCR}
 \usage{
-F_pr_by_pcr(varslist, pars, i)
+F_pr_by_pcr(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_pcr.SEIS.Rd
+++ b/man/F_pr_by_pcr.SEIS.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_pcr.SEIS}
 \title{Compute the prevalence of infection by pcr}
 \usage{
-\method{F_pr_by_pcr}{SEIS}(varslist, pars, i)
+\method{F_pr_by_pcr}{SEIS}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_pcr.SEISd.Rd
+++ b/man/F_pr_by_pcr.SEISd.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_pcr.SEISd}
 \title{Compute the prevalence of infection by pcr}
 \usage{
-\method{F_pr_by_pcr}{SEISd}(varslist, pars, i)
+\method{F_pr_by_pcr}{SEISd}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_pcr.SIP.Rd
+++ b/man/F_pr_by_pcr.SIP.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_pcr.SIP}
 \title{Compute the prevalence of infection by pcr}
 \usage{
-\method{F_pr_by_pcr}{SIP}(varslist, pars, i)
+\method{F_pr_by_pcr}{SIP}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_pcr.SIS.Rd
+++ b/man/F_pr_by_pcr.SIS.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_pcr.SIS}
 \title{Compute the prevalence of infection by PCR}
 \usage{
-\method{F_pr_by_pcr}{SIS}(varslist, pars, i)
+\method{F_pr_by_pcr}{SIS}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_pcr.hMoI.Rd
+++ b/man/F_pr_by_pcr.hMoI.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_pcr.hMoI}
 \title{Compute the prevalence of infection by PCR}
 \usage{
-\method{F_pr_by_pcr}{hMoI}(varslist, pars, i)
+\method{F_pr_by_pcr}{hMoI}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_pcr.trace.Rd
+++ b/man/F_pr_by_pcr.trace.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_pcr.trace}
 \title{Compute the prevalence of infection by PCR}
 \usage{
-\method{F_pr_by_pcr}{trace}(varslist, pars, i)
+\method{F_pr_by_pcr}{trace}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector numeric(0)

--- a/man/F_pr_by_rdt.Rd
+++ b/man/F_pr_by_rdt.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_rdt}
 \title{Compute the prevalence of infection by RDT}
 \usage{
-F_pr_by_rdt(varslist, pars, i)
+F_pr_by_rdt(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_rdt.SEIS.Rd
+++ b/man/F_pr_by_rdt.SEIS.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_rdt.SEIS}
 \title{Compute the prevalence of infection by RDT}
 \usage{
-\method{F_pr_by_rdt}{SEIS}(varslist, pars, i)
+\method{F_pr_by_rdt}{SEIS}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_rdt.SEISd.Rd
+++ b/man/F_pr_by_rdt.SEISd.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_rdt.SEISd}
 \title{Compute the prevalence of infection by RDT}
 \usage{
-\method{F_pr_by_rdt}{SEISd}(varslist, pars, i)
+\method{F_pr_by_rdt}{SEISd}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_rdt.SIP.Rd
+++ b/man/F_pr_by_rdt.SIP.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_rdt.SIP}
 \title{Compute the prevalence of infection by RDT}
 \usage{
-\method{F_pr_by_rdt}{SIP}(varslist, pars, i)
+\method{F_pr_by_rdt}{SIP}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_rdt.SIS.Rd
+++ b/man/F_pr_by_rdt.SIS.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_rdt.SIS}
 \title{Compute the prevalence of infection by RDT}
 \usage{
-\method{F_pr_by_rdt}{SIS}(varslist, pars, i)
+\method{F_pr_by_rdt}{SIS}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_rdt.hMoI.Rd
+++ b/man/F_pr_by_rdt.hMoI.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_rdt.hMoI}
 \title{Compute the prevalence of infection by RDT}
 \usage{
-\method{F_pr_by_rdt}{hMoI}(varslist, pars, i)
+\method{F_pr_by_rdt}{hMoI}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector of length \code{nStrata}

--- a/man/F_pr_by_rdt.trace.Rd
+++ b/man/F_pr_by_rdt.trace.Rd
@@ -4,14 +4,12 @@
 \alias{F_pr_by_rdt.trace}
 \title{Compute the prevalence of infection by RDT}
 \usage{
-\method{F_pr_by_rdt}{trace}(varslist, pars, i)
+\method{F_pr_by_rdt}{trace}(vars, Xpar)
 }
 \arguments{
-\item{varslist}{a parsed list of outputs with variables attached by name}
+\item{vars}{a list with the variables attached by name}
 
-\item{pars}{a list}
-
-\item{i}{the host species index}
+\item{Xpar}{a list defining a model for human infections}
 }
 \value{
 a \link{numeric} vector numeric(0)


### PR DESCRIPTION
To make F_pr easier to use, F_pr now accepts a list of variables, and it dispatches on a set of parameters Xpar.

compute_terms thus passes
1. varslist$XH[[i]] instead of varslist; 2.pars$Xpar[[i]] instead of pars.